### PR TITLE
Install generator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,21 @@
 PATH
   remote: .
   specs:
-    inky-rb (0.0.3)
+    inky-rb (1.3.6.0)
       foundation_emails (~> 2)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    foundation_emails (2.1.0.1)
+    foundation_emails (2.2.0.0)
     rake (11.2.2)
-    rspec-core (3.4.4)
-      rspec-support (~> 3.4.0)
-    rspec-expectations (3.4.0)
+    rspec-core (3.5.0)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-support (3.4.1)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
 
 PLATFORMS
   ruby
@@ -28,4 +28,4 @@ DEPENDENCIES
   rspec-expectations
 
 BUNDLED WITH
-   1.12.4
+   1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    inky-rb (1.3.6.0)
+    inky-rb (1.3.6.1)
       foundation_emails (~> 2)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Inky
 
+[![Gem Version](https://badge.fury.io/rb/inky-rb.svg)](https://badge.fury.io/rb/inky-rb)
+
 Inky is an HTML-based templating language that converts simple HTML into complex, responsive email-ready HTML. Designed for [Foundation for Emails](http://foundation.zurb.com/emails), a responsive email framework from [ZURB](http://zurb.com).
+
+To include only the Foundation for Emails styles in your Asset Pipeline, without Inky, use the [**foundation_emails**](https://github.com/zurb/foundation-emails/#using-the-ruby-gem) gem.
 
 Give Inky simple HTML like this:
 
@@ -52,48 +56,19 @@ Then execute:
 bundle install
 ```
 
-Make sure that the stylesheet included in your email layout imports the Foundation for Emails styles:
+Run the following command to set up the required styles and mailer layout:
 
-```scss
-// app/assets/stylesheets/your_emails_stylesheet.scss
-
-@import "foundation-emails";
+```bash
+rails g inky:install
 ```
+
+(You can specify the generated mailer layout filename like so: `rails g inky:install some_name`)
 
 Rename your email templates to use the `.inky` file extension. Note that you'll still be able to use ERB within the `.inky` templates:
 
 ```
 welcome.html      => welcome.html.inky
 pw_reset.html.erb => pw_reset.html.inky
-```
-
-Ensure your mailer layout has the following structure:
-
-```html
-<!-- app/views/layouts/your_mailer_layout.html.erb -->
-
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <!-- Enables media queries -->
-    <meta name="viewport" content="width=device-width"/>
-    <!-- Link to the email's CSS, which will be inlined into the email -->
-    <%= stylesheet_link_tag "your_emails_stylesheet" %>
-  </head>
-
-  <body>
-    <table class="body" data-made-with-foundation>
-      <tr>
-        <td class="center" align="center" valign="top">
-          <center>
-            <%= yield %>
-          </center>
-        </td>
-      </tr>
-    </table>
-  </body>
-</html>
 ```
 
 You're all set!

--- a/README.md
+++ b/README.md
@@ -74,25 +74,25 @@ Ensure your mailer layout has the following structure:
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <!-- Enables media queries -->
-  <meta name="viewport" content="width=device-width"/>
-  <!-- Link to the email's CSS, which will be inlined into the email -->
-  <link rel="stylesheet" href="assets/css/foundation-emails.css">
-</head>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <!-- Enables media queries -->
+    <meta name="viewport" content="width=device-width"/>
+    <!-- Link to the email's CSS, which will be inlined into the email -->
+    <%= stylesheet_link_tag "your_emails_stylesheet" %>
+  </head>
 
-<body>
-  <table class="body" data-made-with-foundation>
-    <tr>
-      <td class="center" align="center" valign="top">
-        <center>
-          <%= yield %>
-        </center>
-      </td>
-    </tr>
-  </table>
-</body>
+  <body>
+    <table class="body" data-made-with-foundation>
+      <tr>
+        <td class="center" align="center" valign="top">
+          <center>
+            <%= yield %>
+          </center>
+        </td>
+      </tr>
+    </table>
+  </body>
 </html>
 ```
 

--- a/lib/generators/inky/install_generator.rb
+++ b/lib/generators/inky/install_generator.rb
@@ -1,0 +1,29 @@
+require 'rails/generators'
+
+module Inky
+  module Generators
+    class InstallGenerator < ::Rails::Generators::Base
+      desc 'Install Foundation for Emails'
+      source_root File.join(File.dirname(__FILE__), 'templates')
+      argument :layout_name, :type => :string, :default => 'inky_mailer', :banner => 'layout_name'
+
+      def create_mailer_stylesheet
+        template 'foundation_emails.scss', File.join(stylesheets_base_dir, 'foundation_emails.scss')
+      end
+
+      def create_mailer_layout
+        template 'mailer_layout.html.erb', File.join(layouts_base_dir, "#{layout_name.underscore}.html.erb")
+      end
+
+      private
+
+      def stylesheets_base_dir
+        File.join('app', 'assets', 'stylesheets')
+      end
+
+      def layouts_base_dir
+        File.join('app', 'views', 'layouts')
+      end
+    end
+  end
+end

--- a/lib/generators/inky/install_generator.rb
+++ b/lib/generators/inky/install_generator.rb
@@ -5,7 +5,15 @@ module Inky
     class InstallGenerator < ::Rails::Generators::Base
       desc 'Install Foundation for Emails'
       source_root File.join(File.dirname(__FILE__), 'templates')
-      argument :layout_name, :type => :string, :default => 'inky_mailer', :banner => 'layout_name'
+      argument :layout_name, :type => :string, :default => 'mailer', :banner => 'layout_name'
+
+      def preserve_original_mailer_layout
+        return nil unless layout_name == 'mailer'
+
+        original_mailer = File.join(layouts_base_dir, 'mailer.html.erb')
+        rename_filename = File.join(layouts_base_dir, "old_mailer_#{Time.now.to_i}.html.erb")
+        File.rename(original_mailer, rename_filename) if File.exists? original_mailer
+      end
 
       def create_mailer_stylesheet
         template 'foundation_emails.scss', File.join(stylesheets_base_dir, 'foundation_emails.scss')

--- a/lib/generators/inky/templates/foundation_emails.scss
+++ b/lib/generators/inky/templates/foundation_emails.scss
@@ -1,0 +1,1 @@
+@import "foundation-emails";

--- a/lib/generators/inky/templates/mailer_layout.html.erb
+++ b/lib/generators/inky/templates/mailer_layout.html.erb
@@ -1,0 +1,21 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width" />
+
+    <%%= stylesheet_link_tag "foundation_emails" %>
+  </head>
+
+  <body>
+    <table class="body" data-made-with-foundation>
+      <tr>
+        <td class="center" align="center" valign="top">
+          <center>
+            <%%= yield %>
+          </center>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/lib/inky/rails/version.rb
+++ b/lib/inky/rails/version.rb
@@ -1,5 +1,5 @@
 module Inky
   module Rails
-    VERSION = "1.3.6.0"
+    VERSION = "1.3.6.1"
   end
 end


### PR DESCRIPTION
This PR simplifies the setup process by offloading the creation of the emails stylesheet and mailer layout to a generator:

    rails g inky:install

After running this command, the user simply has to ensure their mailer templates have the `.inky` extension, and they're good to go.

README instructions are updated to reflect this as well.