### PR TITLE
Ensure Inky content is unescaped.

### DIFF
--- a/lib/inky.rb
+++ b/lib/inky.rb
@@ -74,7 +74,7 @@ module Inky
       raws.each_with_index do |val, i|
         str = str.sub("###RAW#{i}###", val)
       end
-      return str
+      return str.html_safe
     end
   end
 end


### PR DESCRIPTION
Just adds `.html_safe` to the output of `Inky::Core.re_inject_raws`. Fixes #10 