### PR TITLE
Add a gem configurator to enable changing target inky template engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,11 @@ Run the following command to set up the required styles and mailer layout:
 rails g inky:install
 ```
 
-(You can specify the generated mailer layout filename like so: `rails g inky:install some_name`)
+(You can specify the generated mailer layout filename like so: `rails g inky:install some_name` and also your prefered
+markup language like: `rails g inky:install mailer_layout slim`)
 
-Rename your email templates to use the `.inky` file extension. Note that you'll still be able to use ERB within the `.inky` templates:
+Rename your email templates to use the `.inky` file extension. Note that you'll still be able to use your default
+template engine within the `.inky` templates:
 
 ```
 welcome.html      => welcome.html.inky
@@ -74,6 +76,21 @@ pw_reset.html.erb => pw_reset.html.inky
 You're all set!
 
 ** The majority of email clients ignore linked stylesheets. By using a CSS inliner like `premailer-rails` or `roadie`, you're able to leave your stylesheets in a separate file, keeping your markup lean.
+
+## Alternative template engine
+
+If you do not use ERB for your views and layouts but some other markup like Haml or Slim, you can configure Inky to
+use these languages. To do so, just set an initializer:
+
+```ruby
+# config/initializers/inky.rb
+Inky.configure do |config|
+  config.template_engine = :slim
+end
+```
+
+Check [lib/generators/inky/templates/mailer_layout.html.slim](lib/generators/inky/templates/mailer_layout.html.slim)
+for a Slim example.
 
 ## Custom Elements
 

--- a/lib/component_factory.rb
+++ b/lib/component_factory.rb
@@ -141,7 +141,6 @@ module ComponentFactory
         html += "<table class=\"#{classes.join(' ')} show-for-large\"><tbody><tr><td height=\"#{size_lg}px\" style=\"font-size:#{size_lg}px;line-height:#{size_lg}px;\">&#xA0;</td></tr></tbody></table>"
       end
       if size_sm && size_lg
-        # REXML doesn't like replacing a single element with a double
         html = "<span>#{html}</span>"
       end
       return html

--- a/lib/generators/inky/install_generator.rb
+++ b/lib/generators/inky/install_generator.rb
@@ -11,7 +11,7 @@ module Inky
       def preserve_original_mailer_layout
         return nil unless layout_name == 'mailer'
 
-        original_mailer = File.join(layouts_base_dir, "mailer.html.#{extenstion}")
+        original_mailer = File.join(layouts_base_dir, "mailer.html.#{extension}")
         rename_filename = File.join(layouts_base_dir, "old_mailer_#{Time.now.to_i}.html.erb")
         File.rename(original_mailer, rename_filename) if File.exists? original_mailer
       end

--- a/lib/generators/inky/install_generator.rb
+++ b/lib/generators/inky/install_generator.rb
@@ -6,11 +6,12 @@ module Inky
       desc 'Install Foundation for Emails'
       source_root File.join(File.dirname(__FILE__), 'templates')
       argument :layout_name, :type => :string, :default => 'mailer', :banner => 'layout_name'
+      argument :extension,   :type => :string, :default => 'erb',    :banner => 'extension'
 
       def preserve_original_mailer_layout
         return nil unless layout_name == 'mailer'
 
-        original_mailer = File.join(layouts_base_dir, 'mailer.html.erb')
+        original_mailer = File.join(layouts_base_dir, "mailer.html.#{extenstion}")
         rename_filename = File.join(layouts_base_dir, "old_mailer_#{Time.now.to_i}.html.erb")
         File.rename(original_mailer, rename_filename) if File.exists? original_mailer
       end
@@ -20,7 +21,7 @@ module Inky
       end
 
       def create_mailer_layout
-        template 'mailer_layout.html.erb', File.join(layouts_base_dir, "#{layout_name.underscore}.html.erb")
+        template "mailer_layout.html.#{extension}", File.join(layouts_base_dir, "#{layout_name.underscore}.html.#{extension}")
       end
 
       private

--- a/lib/generators/inky/templates/mailer_layout.html.erb
+++ b/lib/generators/inky/templates/mailer_layout.html.erb
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width" />
 
-    <%%= stylesheet_link_tag "foundation_emails" %>
+    <%= stylesheet_link_tag "foundation_emails" %>
   </head>
 
   <body>
@@ -12,7 +12,7 @@
       <tr>
         <td class="center" align="center" valign="top">
           <center>
-            <%%= yield %>
+            <%= yield %>
           </center>
         </td>
       </tr>

--- a/lib/generators/inky/templates/mailer_layout.html.haml
+++ b/lib/generators/inky/templates/mailer_layout.html.haml
@@ -1,0 +1,13 @@
+!!! Strict
+%html{:xmlns => "http://www.w3.org/1999/xhtml"}
+  %head
+    %meta{:content => "text/html; charset=utf-8", "http-equiv" => "Content-Type"}/
+    %meta{:content => "width=device-width", :name => "viewport"}/
+    = stylesheet_link_tag "foundation_emails"
+  %body
+    %table.body{"data-made-with-foundation" => ""}
+      %tr
+        %td.center{:align => "center", :valign => "top"}
+          %center
+            %container
+              = yield

--- a/lib/generators/inky/templates/mailer_layout.html.slim
+++ b/lib/generators/inky/templates/mailer_layout.html.slim
@@ -1,0 +1,15 @@
+doctype strict
+html[xmlns='http://www.w3.org/1999/xhtml']
+  head
+    meta http-equiv="Content-Type" content="text/html; charset=utf-8"
+    meta name="viewport" content="width=device-width"
+
+    = stylesheet_link_tag "foundation_emails"
+
+  body
+    table class="body" data-made-with-foundation=""
+      tr
+        td class="center" align="center" valign="top"
+          center
+            container
+              = yield

--- a/lib/generators/inky/templates/mailer_layout.html.slim
+++ b/lib/generators/inky/templates/mailer_layout.html.slim
@@ -7,9 +7,9 @@ html[xmlns='http://www.w3.org/1999/xhtml']
     = stylesheet_link_tag "foundation_emails"
 
   body
-    table class="body" data-made-with-foundation=""
+    table.body data-made-with-foundation=""
       tr
-        td class="center" align="center" valign="top"
+        td.center align="center" valign="top"
           center
             container
               = yield

--- a/lib/inky.rb
+++ b/lib/inky.rb
@@ -1,3 +1,5 @@
+require 'inky/configuration'
+
 module Inky
   class Core
     require 'nokogiri'

--- a/lib/inky/configuration.rb
+++ b/lib/inky/configuration.rb
@@ -1,0 +1,31 @@
+module Inky
+  # @return [Inky::Configuration] Inky's current configuration
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  # Set Inky's configuration
+  # @param config [Inky::Configuration]
+  def self.configuration=(config)
+    @configuration = config
+  end
+
+  # Modify Inky's current configuration
+  # @yieldparam [Inky::Configuration] config current Inky config
+  # ```
+  # Inky.configure do |config|
+  #   config.template_engine = :slim
+  # end
+  # ```
+  def self.configure
+    yield configuration
+  end
+
+  class Configuration
+    attr_accessor :template_engine
+
+    def initialize
+      @template_engine = :erb
+    end
+  end
+end

--- a/lib/inky/rails/template_handler.rb
+++ b/lib/inky/rails/template_handler.rb
@@ -1,12 +1,12 @@
 module Inky
   module Rails
     class TemplateHandler
-      def self.erb_handler
-        @@erb_handler ||= ActionView::Template.registered_template_handler(:erb)
+      def self.engine_handler
+        @@engine_handler ||= ActionView::Template.registered_template_handler(::Inky.configuration.template_engine)
       end
 
       def self.call(template)
-        compiled_source = erb_handler.call(template)
+        compiled_source = engine_handler.call(template)
         "Inky::Core.new.release_the_kraken(begin; #{compiled_source};end)"
       end
     end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe "Configuration" do
+  it "default value is :erb" do
+    Inky::Configuration.new.template_engine = :erb
+  end
+
+  describe "#configuration=" do
+    it "can set value" do
+      config = Inky::Configuration.new
+      config.template_engine = :haml
+      expect(config.template_engine).to eq(:haml)
+    end
+  end
+
+  describe "#configuration=" do
+    before do
+      Inky.configure do |config|
+        config.template_engine = :haml
+      end
+    end
+
+    it "returns :haml as configured template_engine" do
+      template_engine = Inky.configuration.template_engine
+
+      expect(template_engine).to be_a(Symbol)
+      expect(template_engine).to eq(:haml)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'inky'
+require 'nokogiri'
 
-require 'rexml/document'
 def compare(input, expected)
   inky = Inky::Core.new
   output = inky.release_the_kraken(input)


### PR DESCRIPTION
Paving the way for other configuration variables, this PR implements
the "Configurator Pattern".

To change default ERB template engine, set an initializer like this:
```ruby
# config/initializers/inky.rb
Inky.configure do |config|
  config.template_engine = :slim
end
```

Of course, you have to ensure this template is loaded in you app.

Rails generator is amended to output Slim or Haml versions of mailer_layout.

Also updates README files concordantly, and remove remaining references to
REXML after Nokogiri replacement.

Fixes #14