### PR TITLE
Columns pass through

### DIFF
--- a/lib/component_factory.rb
+++ b/lib/component_factory.rb
@@ -98,7 +98,7 @@ module ComponentFactory
     if large_size.to_i == self.column_count && subrows.size == 0
       expander = "<th class=\"expander\"></th>"
     end
-    "<th class=\"#{classes.join(' ')}\"><table><tr><th>#{inner}</th>#{expander}</tr></table></th>"
+    "<th class=\"#{classes.join(' ')}\" #{_pass_through_attributes(component)}><table><tr><th>#{inner}</th>#{expander}</tr></table></th>"
   end
 
   def _transform_block_grid(component, inner)

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -269,6 +269,23 @@ RSpec.describe 'Grid' do
 
     compare(input, expected)
   end
+
+  it 'transfers attributes like valign' do
+    input = '<columns small="6" valign="middle" foo="bar">x</columns>'
+    expected = <<-HTML
+      <th class="small-6 large-6 columns first last" valign="middle" foo="bar">
+        <table>
+          <tr>
+            <th>
+              x
+            </th>
+          </tr>
+        </table>
+      </th>
+    HTML
+
+    compare(input, expected)
+  end
 end
 
 RSpec.describe 'Block Grid' do


### PR DESCRIPTION
Fixes #13, improves on #24 by being simpler and passing all attributes, as `inky` (node) does.