### PR TITLE
Add comparison tests with official inky

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 pkg
+spec/_cases_output

--- a/lib/component_factory.rb
+++ b/lib/component_factory.rb
@@ -4,7 +4,7 @@ module ComponentFactory
     # TODO:  Handle changed names
     transform_method = :"_transform_#{component_lookup[elem.name]}"
     return unless respond_to?(transform_method)
-    Nokogiri::XML(send(transform_method, elem, inner)).root
+    send(transform_method, elem, inner)
   end
 
   tags = %w[class id href size large no-expander small target]

--- a/lib/component_factory.rb
+++ b/lib/component_factory.rb
@@ -55,7 +55,8 @@ module ComponentFactory
 
   def _transform_menu_item(component, inner)
     target = _target_attribute(component)
-    %{<th class="menu-item"><a href="#{component.attr('href')}"#{target}>#{inner}</a></th>}
+    attributes = _combine_attributes(component, 'menu-item')
+    %{<th #{attributes}><a href="#{component.attr('href')}"#{target}>#{inner}</a></th>}
   end
 
   def _transform_container(component, inner)

--- a/lib/component_factory.rb
+++ b/lib/component_factory.rb
@@ -49,8 +49,8 @@ module ComponentFactory
   end
 
   def _transform_menu(component, inner)
-    classes = _combine_classes(component, 'menu')
-    %{<table class="#{classes}"><tr><td><table><tr>#{inner}</tr></table></td></tr></table>}
+    attributes = _combine_attributes(component, 'menu')
+    %{<table #{attributes}><tr><td><table><tr>#{inner}</tr></table></td></tr></table>}
   end
 
   def _transform_menu_item(component, inner)

--- a/lib/component_factory.rb
+++ b/lib/component_factory.rb
@@ -25,6 +25,11 @@ module ComponentFactory
     [elem['class'], extra_classes].join(' ')
   end
 
+  def _combine_attributes(elem, extra_classes = nil)
+    classes = _combine_classes(elem, extra_classes)
+    [_pass_through_attributes(elem), classes && %{class="#{classes}"}].join
+  end
+
   def _target_attribute(elem)
     elem.attributes['target'] ? %{ target="#{elem.attributes['target']}"} : ''
   end
@@ -59,9 +64,7 @@ module ComponentFactory
   end
 
   def _transform_row(component, inner)
-    classes = _combine_classes(component, 'row')
-    attrs = _pass_through_attributes(component)
-    %{<table #{attrs}class="#{classes}"><tbody><tr>#{inner}</tr></tbody></table>}
+    %{<table #{_combine_attributes(component, 'row')}><tbody><tr>#{inner}</tr></tbody></table>}
   end
 
   # in inky.js this is factored out into makeClumn.  TBD if we need that here.

--- a/lib/component_factory.rb
+++ b/lib/component_factory.rb
@@ -132,7 +132,7 @@ module ComponentFactory
   end
 
   def _transform_wrapper(component, inner)
-    classes = _combine_classes(component, 'wrapper')
-    %{<table class="#{classes}" align="center"><tr><td class="wrapper-inner">#{inner}</td></tr></table>}
+    attributes = _combine_attributes(component, 'wrapper')
+    %{<table #{attributes} align="center"><tr><td class="wrapper-inner">#{inner}</td></tr></table>}
   end
 end

--- a/lib/component_factory.rb
+++ b/lib/component_factory.rb
@@ -21,10 +21,8 @@ module ComponentFactory
     (elem.attr('class') || '').include?(klass)
   end
 
-  def _class_array(elem, defaults = [])
-    classes = elem['class']
-    defaults.concat(classes.split(' ')) if classes
-    defaults
+  def _class_array(elem, extra_classes)
+    [elem['class'], extra_classes].join(' ')
   end
 
   def _target_attribute(elem)
@@ -40,13 +38,13 @@ module ComponentFactory
     end
     inner = "<center>#{inner}</center>" if expand
 
-    classes = _class_array(component, ['button'])
+    classes = _class_array(component, 'button')
     expander = '<td class="expander"></td>' if expand
     %{<table class="#{classes.join(' ')}"><tr><td><table><tr><td>#{inner}</td></tr></table></td>#{expander}</tr></table>}
   end
 
   def _transform_menu(component, inner)
-    classes = _class_array(component, ['menu'])
+    classes = _class_array(component, 'menu')
     %{<table class="#{classes.join(' ')}"><tr><td><table><tr>#{inner}</tr></table></td></tr></table>}
   end
 
@@ -56,12 +54,12 @@ module ComponentFactory
   end
 
   def _transform_container(component, inner)
-    classes = _class_array(component, ['container'])
+    classes = _class_array(component, 'container')
     %{<table class="#{classes.join(' ')}"><tbody><tr><td>#{inner}</td></tr></tbody></table>}
   end
 
   def _transform_row(component, inner)
-    classes = _class_array(component, ['row'])
+    classes = _class_array(component, 'row')
     attrs = _pass_through_attributes(component)
     %{<table #{attrs}class="#{classes.join(' ')}"><tbody><tr>#{inner}</tr></tbody></table>}
   end
@@ -76,7 +74,7 @@ module ComponentFactory
     small_size = small_val || column_count
     large_size = large_val || small_val || (column_count / col_count).to_i
 
-    classes = _class_array(component, ["small-#{small_size}", "large-#{large_size}", "columns"])
+    classes = _class_array(component, "small-#{small_size} large-#{large_size} columns")
 
     classes.push('first') unless component.previous_element
     classes.push('last') unless component.next_element
@@ -88,7 +86,7 @@ module ComponentFactory
   end
 
   def _transform_block_grid(component, inner)
-    classes = _class_array(component, ['block-grid', "up-#{component.attr('up')}"])
+    classes = _class_array(component, "block-grid up-#{component.attr('up')}")
     %{<table class="#{classes.join(' ')}"><tr>#{inner}</tr></table>}
   end
 
@@ -97,11 +95,11 @@ module ComponentFactory
     # sometimes appears to miss elements that show up in size
     component.elements.each do |child|
       child['align'] = 'center'
-      child_classes = _class_array(child, ['float-center'])
+      child_classes = _class_array(child, 'float-center')
       child['class'] = child_classes.join(' ')
       items = component.elements.css(".menu-item").to_a.concat(component.elements.css("item").to_a)
       items.each do |item|
-        item_classes = _class_array(item, ['float-center'])
+        item_classes = _class_array(item, 'float-center')
         item['class'] = item_classes.join(' ')
       end
     end
@@ -109,12 +107,12 @@ module ComponentFactory
   end
 
   def _transform_callout(component, inner)
-    classes = _class_array(component, ['callout-inner'])
+    classes = _class_array(component, 'callout-inner')
     %{<table class="callout"><tr><th class="#{classes.join(' ')}">#{inner}</th><th class="expander"></th></tr></table>}
   end
 
   def _transform_spacer(component, _inner)
-    classes = _class_array(component, ['spacer'])
+    classes = _class_array(component, 'spacer')
     build_table = ->(size, extra) { %{<table class="#{classes.join(' ')} #{extra}"><tbody><tr><td height="#{size}px" style="font-size:#{size}px;line-height:#{size}px;">&#xA0;</td></tr></tbody></table>} }
     size = component.attr('size')
     size_sm = component.attr('size-sm')
@@ -131,7 +129,7 @@ module ComponentFactory
   end
 
   def _transform_wrapper(component, inner)
-    classes = _class_array(component, ['wrapper'])
+    classes = _class_array(component, 'wrapper')
     %{<table class="#{classes.join(' ')}" align="center"><tr><td class="wrapper-inner">#{inner}</td></tr></table>}
   end
 end

--- a/lib/component_factory.rb
+++ b/lib/component_factory.rb
@@ -21,7 +21,7 @@ module ComponentFactory
     (elem.attr('class') || '').include?(klass)
   end
 
-  def _class_array(elem, extra_classes)
+  def _combine_classes(elem, extra_classes)
     [elem['class'], extra_classes].join(' ')
   end
 
@@ -38,14 +38,14 @@ module ComponentFactory
     end
     inner = "<center>#{inner}</center>" if expand
 
-    classes = _class_array(component, 'button')
+    classes = _combine_classes(component, 'button')
     expander = '<td class="expander"></td>' if expand
-    %{<table class="#{classes.join(' ')}"><tr><td><table><tr><td>#{inner}</td></tr></table></td>#{expander}</tr></table>}
+    %{<table class="#{classes}"><tr><td><table><tr><td>#{inner}</td></tr></table></td>#{expander}</tr></table>}
   end
 
   def _transform_menu(component, inner)
-    classes = _class_array(component, 'menu')
-    %{<table class="#{classes.join(' ')}"><tr><td><table><tr>#{inner}</tr></table></td></tr></table>}
+    classes = _combine_classes(component, 'menu')
+    %{<table class="#{classes}"><tr><td><table><tr>#{inner}</tr></table></td></tr></table>}
   end
 
   def _transform_menu_item(component, inner)
@@ -54,14 +54,14 @@ module ComponentFactory
   end
 
   def _transform_container(component, inner)
-    classes = _class_array(component, 'container')
-    %{<table class="#{classes.join(' ')}"><tbody><tr><td>#{inner}</td></tr></tbody></table>}
+    classes = _combine_classes(component, 'container')
+    %{<table class="#{classes}"><tbody><tr><td>#{inner}</td></tr></tbody></table>}
   end
 
   def _transform_row(component, inner)
-    classes = _class_array(component, 'row')
+    classes = _combine_classes(component, 'row')
     attrs = _pass_through_attributes(component)
-    %{<table #{attrs}class="#{classes.join(' ')}"><tbody><tr>#{inner}</tr></tbody></table>}
+    %{<table #{attrs}class="#{classes}"><tbody><tr>#{inner}</tr></tbody></table>}
   end
 
   # in inky.js this is factored out into makeClumn.  TBD if we need that here.
@@ -74,20 +74,20 @@ module ComponentFactory
     small_size = small_val || column_count
     large_size = large_val || small_val || (column_count / col_count).to_i
 
-    classes = _class_array(component, "small-#{small_size} large-#{large_size} columns")
+    classes = _combine_classes(component, "small-#{small_size} large-#{large_size} columns")
 
-    classes.push('first') unless component.previous_element
-    classes.push('last') unless component.next_element
+    classes << ' first' unless component.previous_element
+    classes << ' last' unless component.next_element
 
     subrows = component.elements.css(".row").to_a.concat(component.elements.css("row").to_a)
     expander = %{<th class="expander"></th>} if large_size.to_i == column_count && subrows.empty?
 
-    %{<th class="#{classes.join(' ')}" #{_pass_through_attributes(component)}><table><tr><th>#{inner}</th>#{expander}</tr></table></th>}
+    %{<th class="#{classes}" #{_pass_through_attributes(component)}><table><tr><th>#{inner}</th>#{expander}</tr></table></th>}
   end
 
   def _transform_block_grid(component, inner)
-    classes = _class_array(component, "block-grid up-#{component.attr('up')}")
-    %{<table class="#{classes.join(' ')}"><tr>#{inner}</tr></table>}
+    classes = _combine_classes(component, "block-grid up-#{component.attr('up')}")
+    %{<table class="#{classes}"><tr>#{inner}</tr></table>}
   end
 
   def _transform_center(component, _inner)
@@ -95,25 +95,23 @@ module ComponentFactory
     # sometimes appears to miss elements that show up in size
     component.elements.each do |child|
       child['align'] = 'center'
-      child_classes = _class_array(child, 'float-center')
-      child['class'] = child_classes.join(' ')
+      child['class'] = _combine_classes(child, 'float-center')
       items = component.elements.css(".menu-item").to_a.concat(component.elements.css("item").to_a)
       items.each do |item|
-        item_classes = _class_array(item, 'float-center')
-        item['class'] = item_classes.join(' ')
+        item['class'] = _combine_classes(item, 'float-center')
       end
     end
     component.to_s
   end
 
   def _transform_callout(component, inner)
-    classes = _class_array(component, 'callout-inner')
-    %{<table class="callout"><tr><th class="#{classes.join(' ')}">#{inner}</th><th class="expander"></th></tr></table>}
+    classes = _combine_classes(component, 'callout-inner')
+    %{<table class="callout"><tr><th class="#{classes}">#{inner}</th><th class="expander"></th></tr></table>}
   end
 
   def _transform_spacer(component, _inner)
-    classes = _class_array(component, 'spacer')
-    build_table = ->(size, extra) { %{<table class="#{classes.join(' ')} #{extra}"><tbody><tr><td height="#{size}px" style="font-size:#{size}px;line-height:#{size}px;">&#xA0;</td></tr></tbody></table>} }
+    classes = _combine_classes(component, 'spacer')
+    build_table = ->(size, extra) { %{<table class="#{classes} #{extra}"><tbody><tr><td height="#{size}px" style="font-size:#{size}px;line-height:#{size}px;">&#xA0;</td></tr></tbody></table>} }
     size = component.attr('size')
     size_sm = component.attr('size-sm')
     size_lg = component.attr('size-lg')
@@ -129,7 +127,7 @@ module ComponentFactory
   end
 
   def _transform_wrapper(component, inner)
-    classes = _class_array(component, 'wrapper')
-    %{<table class="#{classes.join(' ')}" align="center"><tr><td class="wrapper-inner">#{inner}</td></tr></table>}
+    classes = _combine_classes(component, 'wrapper')
+    %{<table class="#{classes}" align="center"><tr><td class="wrapper-inner">#{inner}</td></tr></table>}
   end
 end

--- a/lib/component_factory.rb
+++ b/lib/component_factory.rb
@@ -124,7 +124,6 @@ module ComponentFactory
       html = ''
       html << build_table[size_sm, 'hide-for-large'] if size_sm
       html << build_table[size_lg, 'show-for-large'] if size_lg
-      html = "<span>#{html}</span>" if size_sm && size_lg
       html
     else
       build_table[size || 16, nil]

--- a/lib/component_factory.rb
+++ b/lib/component_factory.rb
@@ -60,8 +60,8 @@ module ComponentFactory
   end
 
   def _transform_container(component, inner)
-    classes = _combine_classes(component, 'container')
-    %{<table class="#{classes}"><tbody><tr><td>#{inner}</td></tr></tbody></table>}
+    attributes = _combine_attributes(component, 'container')
+    %{<table #{attributes} align="center"><tbody><tr><td>#{inner}</td></tr></tbody></table>}
   end
 
   def _transform_row(component, inner)

--- a/lib/component_factory.rb
+++ b/lib/component_factory.rb
@@ -64,7 +64,8 @@ module ComponentFactory
   end
 
   def _transform_row(component, inner)
-    %{<table #{_combine_attributes(component, 'row')}><tbody><tr>#{inner}</tr></tbody></table>}
+    attributes = _combine_attributes(component, 'row')
+    %{<table #{attributes}><tbody><tr>#{inner}</tr></tbody></table>}
   end
 
   # in inky.js this is factored out into makeClumn.  TBD if we need that here.
@@ -109,7 +110,8 @@ module ComponentFactory
 
   def _transform_callout(component, inner)
     classes = _combine_classes(component, 'callout-inner')
-    %{<table class="callout"><tr><th class="#{classes}">#{inner}</th><th class="expander"></th></tr></table>}
+    attributes = _pass_through_attributes(component)
+    %{<table #{attributes}class="callout"><tr><th class="#{classes}">#{inner}</th><th class="expander"></th></tr></table>}
   end
 
   def _transform_spacer(component, _inner)

--- a/lib/component_factory.rb
+++ b/lib/component_factory.rb
@@ -18,7 +18,7 @@ module ComponentFactory
   end
 
   def _has_class(elem, klass)
-    (elem.attr('class') || '').include?(klass)
+    elem.attr('class') =~ /(^|\s)#{klass}($|\s)/
   end
 
   def _combine_classes(elem, extra_classes)

--- a/lib/inky.rb
+++ b/lib/inky.rb
@@ -1,7 +1,7 @@
 module Inky
   class Core
     require 'nokogiri'
-    require 'component_factory'
+    require_relative 'component_factory'
     attr_accessor :components, :column_count, :component_lookup, :component_tags
 
     include ComponentFactory

--- a/lib/inky.rb
+++ b/lib/inky.rb
@@ -31,15 +31,13 @@ module Inky
     def release_the_kraken(xml_string)
       xml_string = xml_string.gsub(/doctype/i, 'DOCTYPE')
       raws, str = Inky::Core.extract_raws(xml_string)
-      xml_doc = Nokogiri::XML(str)
-      transform_doc(xml_doc.root) if components_exist?(xml_doc)
-      string = xml_doc.to_s
-      string.sub!(/^<\?xml.*\?>\n/, '')
+      parse_cmd = str =~ /<html/i ? :parse : :fragment
+      html = Nokogiri::HTML.public_send(parse_cmd, str)
+      html.elements.each do |elem|
+        transform_doc(elem)
+      end
+      string = html.to_html(encoding: 'US-ASCII')
       Inky::Core.re_inject_raws(string, raws)
-    end
-
-    def components_exist?(_xml_doc)
-      true
     end
 
     def transform_doc(elem)

--- a/lib/inky/rails/version.rb
+++ b/lib/inky/rails/version.rb
@@ -1,6 +1,6 @@
 module Inky
   module Rails
-    VERSION = "1.3.6.3".freeze
+    VERSION = "1.3.7.0".freeze
   end
   NODE_VERSION, GEM_VERSION = Rails::VERSION.rpartition('.').map(&:freeze)
 end

--- a/lib/inky/rails/version.rb
+++ b/lib/inky/rails/version.rb
@@ -2,4 +2,5 @@ module Inky
   module Rails
     VERSION = "1.3.6.3".freeze
   end
+  NODE_VERSION, GEM_VERSION = Rails::VERSION.rpartition('.').map(&:freeze)
 end

--- a/spec/cases/button/no_link.inky
+++ b/spec/cases/button/no_link.inky
@@ -1,0 +1,1 @@
+<button>I'm missing an href</button>

--- a/spec/cases/button/with_expand_class.inky
+++ b/spec/cases/button/with_expand_class.inky
@@ -1,0 +1,3 @@
+<button href="http://example.com" class="expand foo">
+  A label
+</button>

--- a/spec/cases/button/with_image.inky
+++ b/spec/cases/button/with_image.inky
@@ -1,0 +1,5 @@
+<!-- pending -->
+
+<button href="#">
+  <img src="http://www.example.com/" width="600" height="400"/>
+</button>

--- a/spec/cases/button/with_image.inky
+++ b/spec/cases/button/with_image.inky
@@ -1,5 +1,3 @@
-<!-- pending -->
-
 <button href="#">
   <img src="http://www.example.com/" width="600" height="400"/>
 </button>

--- a/spec/cases/button/with_link.inky
+++ b/spec/cases/button/with_link.inky
@@ -1,0 +1,3 @@
+<button href="http://example.com" class="some classes" foo="bar">
+	A label
+</button>

--- a/spec/cases/button/with_tricky_class.inky
+++ b/spec/cases/button/with_tricky_class.inky
@@ -1,0 +1,5 @@
+<!-- pending -->
+
+<button href="http://example.com" class="noexpand">
+  A label
+</button>

--- a/spec/cases/button/with_tricky_class.inky
+++ b/spec/cases/button/with_tricky_class.inky
@@ -1,5 +1,19 @@
-<!-- pending -->
-
 <button href="http://example.com" class="noexpand">
+  A label
+</button>
+
+<button href="http://example.com" class="expand-niet">
+  A label
+</button>
+
+<button href="http://example.com" class="expand foo">
+  A label
+</button>
+
+<button href="http://example.com" class="foo expand">
+  A label
+</button>
+
+<button href="http://example.com" class="foo expand bar">
   A label
 </button>

--- a/spec/cases/callout/basic.inky
+++ b/spec/cases/callout/basic.inky
@@ -1,0 +1,1 @@
+<callout>Simple callout</callout>

--- a/spec/cases/callout/with_attributes.inky
+++ b/spec/cases/callout/with_attributes.inky
@@ -1,0 +1,5 @@
+<!-- pending -->
+
+<callout class="some klasses" foo="bar">
+  <p>I'm in a callout!</p>
+</callout>

--- a/spec/cases/callout/with_attributes.inky
+++ b/spec/cases/callout/with_attributes.inky
@@ -1,5 +1,3 @@
-<!-- pending -->
-
 <callout class="some klasses" foo="bar">
   <p>I'm in a callout!</p>
 </callout>

--- a/spec/cases/general/multiple_root.inky
+++ b/spec/cases/general/multiple_root.inky
@@ -1,4 +1,2 @@
-<!-- pending -->
-
 <callout>Hey</callout>
 <callout>You</callout>

--- a/spec/cases/general/multiple_root.inky
+++ b/spec/cases/general/multiple_root.inky
@@ -1,0 +1,4 @@
+<!-- pending -->
+
+<callout>Hey</callout>
+<callout>You</callout>

--- a/spec/cases/general/no_tag.inky
+++ b/spec/cases/general/no_tag.inky
@@ -1,0 +1,3 @@
+<!-- pending -->
+
+Very simple test...

--- a/spec/cases/general/no_tag.inky
+++ b/spec/cases/general/no_tag.inky
@@ -1,3 +1,1 @@
-<!-- pending -->
-
 Very simple test...

--- a/spec/cases/general/root_within_text.inky
+++ b/spec/cases/general/root_within_text.inky
@@ -1,0 +1,5 @@
+<!-- pending -->
+
+Text before
+<callout>Ho</callout>
+Text after

--- a/spec/cases/general/root_within_text.inky
+++ b/spec/cases/general/root_within_text.inky
@@ -1,5 +1,3 @@
-<!-- pending -->
-
 Text before
 <callout>Ho</callout>
 Text after

--- a/spec/cases/general/void_html_elements.inky
+++ b/spec/cases/general/void_html_elements.inky
@@ -1,5 +1,3 @@
-<!-- pending -->
-
 <callout>
 Hello
 <br/>

--- a/spec/cases/general/void_html_elements.inky
+++ b/spec/cases/general/void_html_elements.inky
@@ -1,0 +1,8 @@
+<!-- pending -->
+
+<callout>
+Hello
+<br/>
+Here's an image:
+<img src="http://www.example.com" width="400" height="200"/>
+</callout>

--- a/spec/cases/grid/columns.inky
+++ b/spec/cases/grid/columns.inky
@@ -1,0 +1,1 @@
+<columns class="some classes" foo="bar">First column</columns>

--- a/spec/cases/grid/container.inky
+++ b/spec/cases/grid/container.inky
@@ -1,0 +1,3 @@
+<!-- pending -->
+
+<container class="klass" foo="bar">some content</container>

--- a/spec/cases/grid/container.inky
+++ b/spec/cases/grid/container.inky
@@ -1,3 +1,1 @@
-<!-- pending -->
-
 <container class="klass" foo="bar">some content</container>

--- a/spec/cases/grid/container_with_align.inky
+++ b/spec/cases/grid/container_with_align.inky
@@ -1,3 +1,1 @@
-<!-- pending -->
-
 <container align="left">some content</container>

--- a/spec/cases/grid/container_with_align.inky
+++ b/spec/cases/grid/container_with_align.inky
@@ -1,0 +1,3 @@
+<!-- pending -->
+
+<container align="left">some content</container>

--- a/spec/cases/grid/row.inky
+++ b/spec/cases/grid/row.inky
@@ -1,0 +1,1 @@
+<row class="some klasses" foo="bar">columns here</row>

--- a/spec/cases/grid/row_with_columns.inky
+++ b/spec/cases/grid/row_with_columns.inky
@@ -1,0 +1,5 @@
+<row class="collapse">
+  <columns>First column</columns>
+  <columns>Second column</columns>
+  <columns>Last column</columns>
+</row>

--- a/spec/cases/menu/item.inky
+++ b/spec/cases/menu/item.inky
@@ -1,0 +1,3 @@
+<!-- pending -->
+
+<item class="some classes" foo="bar" href="http://example.com">An item</item>

--- a/spec/cases/menu/item.inky
+++ b/spec/cases/menu/item.inky
@@ -1,3 +1,1 @@
-<!-- pending -->
-
 <item class="some classes" foo="bar" href="http://example.com">An item</item>

--- a/spec/cases/menu/menu.inky
+++ b/spec/cases/menu/menu.inky
@@ -1,0 +1,3 @@
+<!-- pending -->
+
+<menu class="some classes" foo="bar"/>

--- a/spec/cases/menu/menu.inky
+++ b/spec/cases/menu/menu.inky
@@ -1,3 +1,1 @@
-<!-- pending -->
-
 <menu class="some classes" foo="bar"/>

--- a/spec/cases/menu/menu_with_align.inky
+++ b/spec/cases/menu/menu_with_align.inky
@@ -1,0 +1,1 @@
+<menu align="left"/>

--- a/spec/cases/menu/menu_with_items.inky
+++ b/spec/cases/menu/menu_with_items.inky
@@ -1,0 +1,5 @@
+<menu class="small-vertical">
+  <item href="http://example.com/1">An item</item>
+  <item href="http://example.com/2">Another Item</item>
+  <item href="http://example.com/3">Last Item</item>
+</menu>

--- a/spec/cases/spacer/basic.inky
+++ b/spec/cases/spacer/basic.inky
@@ -1,0 +1,5 @@
+<div>
+  Stuff on top
+  <spacer/>
+  Stuff on bottom
+</div>

--- a/spec/cases/spacer/with_size.inky
+++ b/spec/cases/spacer/with_size.inky
@@ -1,0 +1,5 @@
+<div>
+  Stuff on top
+  <spacer class="some classes" foo="bar" size="42"/>
+  Stuff on bottom
+</div>

--- a/spec/cases/spacer/with_size_lg.inky
+++ b/spec/cases/spacer/with_size_lg.inky
@@ -1,0 +1,4 @@
+<div>
+  Stuff on top
+  <spacer class="some classes" foo="bar" size-lg="666"/>
+<p>Stuff on bottom</p>

--- a/spec/cases/spacer/with_size_sm.inky
+++ b/spec/cases/spacer/with_size_sm.inky
@@ -1,0 +1,5 @@
+<div>
+  Stuff on top
+  <spacer class="some classes" foo="bar" size-sm="42"></spacer>
+  Stuff on bottom
+</div>

--- a/spec/cases/spacer/with_size_sm_and_lg.inky
+++ b/spec/cases/spacer/with_size_sm_and_lg.inky
@@ -1,5 +1,3 @@
-<!-- pending -->
-
 <div>
   Stuff on top
   <spacer class="some classes" foo="bar" size-sm="42" size-lg="666"/>

--- a/spec/cases/spacer/with_size_sm_and_lg.inky
+++ b/spec/cases/spacer/with_size_sm_and_lg.inky
@@ -1,0 +1,7 @@
+<!-- pending -->
+
+<div>
+  Stuff on top
+  <spacer class="some classes" foo="bar" size-sm="42" size-lg="666"/>
+  Stuff on bottom
+</div>

--- a/spec/cases/wrapper/basic.inky
+++ b/spec/cases/wrapper/basic.inky
@@ -1,0 +1,1 @@
+<wrapper>In the wrap</wrapper>

--- a/spec/cases/wrapper/with_align.inky
+++ b/spec/cases/wrapper/with_align.inky
@@ -1,0 +1,3 @@
+<!-- pending -->
+
+<wrapper align="left">In the wrap</wrapper>

--- a/spec/cases/wrapper/with_align.inky
+++ b/spec/cases/wrapper/with_align.inky
@@ -1,3 +1,1 @@
-<!-- pending -->
-
 <wrapper align="left">In the wrap</wrapper>

--- a/spec/cases/wrapper/with_attributes.inky
+++ b/spec/cases/wrapper/with_attributes.inky
@@ -1,3 +1,1 @@
-<!-- pending -->
-
 <wrapper class="some classes" foo="bar">In the wrap</wrapper>

--- a/spec/cases/wrapper/with_attributes.inky
+++ b/spec/cases/wrapper/with_attributes.inky
@@ -1,0 +1,3 @@
+<!-- pending -->
+
+<wrapper class="some classes" foo="bar">In the wrap</wrapper>

--- a/spec/cases_spec.rb
+++ b/spec/cases_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+require 'json'
+
+INKY_VERSION_REQUIRED = Inky::NODE_VERSION
+
+def npm_packages
+  JSON.parse(`npm list -g --depth=1 --json=true`)
+rescue
+  puts <<-Err
+    npm not detected, skipping comparison tests.
+  Err
+  nil
+end
+
+def inky_cli_ok?
+  return unless packages = npm_packages
+  version = packages['dependencies']['inky-cli']['dependencies']['inky']['version']
+  return true if version >= INKY_VERSION_REQUIRED
+  puts "Requires inky version #{INKY_VERSION_REQUIRED}+, currently installed #{version}"
+  false
+rescue
+  puts <<-Err
+    inky-cli not globally installed, skipping comparison tests.
+    Install with:
+        npm install inky-cli -g
+  Err
+  false
+end
+
+RSpec.describe "Inky-rb" do
+  context "compared to inky-cli" do
+    Dir['./spec/cases/*'].each do |path|
+      folder = File.basename(path)
+      output_path = "./spec/_cases_output/#{File.basename(folder)}"
+      sources = "#{path}/*.inky"
+      source_paths = Dir[sources]
+
+      context "for #{folder} components" do
+        before(:all) do
+          shell = source_paths.map { |p| "inky #{p} #{output_path}" }
+          `#{shell.join(' && ')}`
+        end
+
+        source_paths.each do |filepath|
+          file = File.basename(filepath, '.inky')
+          content = File.read(filepath)
+          exec = content =~ /^<!--\s*(pending|skip)/ ? $1 : :it
+          send exec, "provides the same results for #{file}" do
+            compare(content, File.read("#{output_path}/#{file}.inky"))
+          end
+        end
+      end
+    end
+  end if inky_cli_ok?
+end

--- a/spec/components_spec.rb
+++ b/spec/components_spec.rb
@@ -301,7 +301,6 @@ RSpec.describe "Spacer" do
   it 'creates a spacer element for small and large screens with correct sizes' do
     input = '<spacer size-sm="10" size-lg="20"></spacer>'
     expected = <<-HTML
-      <span>
         <table class="spacer hide-for-large">
           <tbody>
             <tr>
@@ -316,7 +315,6 @@ RSpec.describe "Spacer" do
             </tr>
           </tbody>
         </table>
-      </span>
     HTML
 
     compare(input, expected)

--- a/spec/components_spec.rb
+++ b/spec/components_spec.rb
@@ -356,7 +356,7 @@ end
 RSpec.describe "raw" do
   it 'creates a wrapper that ignores anything inside' do
     input = "<body><raw><<LCG ProgramTG LCG Coupon Code Default='246996'>></raw></body>"
-    expected = "<body><<LCG ProgramTG LCG Coupon Code Default='246996'>></body>\n"
+    expected = "<body><<LCG ProgramTG LCG Coupon Code Default='246996'>></body>"
 
     # Can't do vanilla compare because the second will fail to parse
     inky = Inky::Core.new

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Container" do
   it 'works when parsing a full HTML document' do
     input = <<-INKY
       <!doctype html> <html>
-        <head></head>
+        <head><meta http-equiv="Content-Type" content="text/html; charset=US-ASCII"></head>
         <body>
           <container></container>
         </body>
@@ -27,7 +27,7 @@ RSpec.describe "Container" do
     expected = <<-HTML
       <!DOCTYPE html>
       <html>
-        <head></head>
+        <head><meta http-equiv="Content-Type" content="text/html; charset=US-ASCII"></head>
         <body>
           <table class="container">
             <tbody>

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Container" do
   it "creates a container table" do
     input = '<container></container>'
     expected = <<-HTML
-      <table class="container">
+      <table class="container" align="center">
         <tbody>
           <tr>
             <td></td>
@@ -29,7 +29,7 @@ RSpec.describe "Container" do
       <html>
         <head><meta http-equiv="Content-Type" content="text/html; charset=US-ASCII"></head>
         <body>
-          <table class="container">
+          <table class="container" align="center">
             <tbody>
               <tr>
                 <td></td>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ def reformat_html(html)
     .gsub(/ "/, '"').gsub(/\=" /, '="')         # Remove leading/trailing spaces inside attributes
     .gsub(/ </, '<').gsub(/> /, '>')            # Remove leading/trailing spaces inside tags
     .gsub(' data-parsed=""', '')                # Don't consider this known inky-node artefact
+    .gsub('&#xA0', '&#160')                     # These are the same entity...
     .gsub(/class\="([^"]+)"/) do                # Sort class names
       classes = $1.split(' ').sort.join(' ')
       %{class="#{classes}"}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,14 +2,15 @@ require 'inky'
 
 def reformat_html(html)
   html
-    .gsub(/\s+/, ' ')                           # Compact all whitespace to a single space
-    .gsub(/> *</, ">\n<")                       # Use returns between tags
-    .gsub(%r{<(\w+)([^>]*)>\n</\1>}, '<\1\2/>') # Auto close empty tags, e.g. <hr>\n</hr> => <hr/>
-    .gsub(/ "/, '"').gsub(/\=" /, '="')         # Remove leading/trailing spaces inside attributes
-    .gsub(/ </, '<').gsub(/> /, '>')            # Remove leading/trailing spaces inside tags
-    .gsub(' data-parsed=""', '')                # Don't consider this known inky-node artefact
-    .gsub('&#xA0', '&#160')                     # These are the same entity...
-    .gsub(/class\="([^"]+)"/) do                # Sort class names
+    .gsub(/\s+/, ' ')                                 # Compact all whitespace to a single space
+    .gsub(/> *</, ">\n<")                             # Use returns between tags
+    .gsub(%r{<(\w+)([^>]*)>\n</\1>}, '<\1\2/>')       # Auto close empty tags, e.g. <hr>\n</hr> => <hr/>
+    .gsub(/ "/, '"').gsub(/\=" /, '="')               # Remove leading/trailing spaces inside attributes
+    .gsub(/ </, '<').gsub(/> /, '>')                  # Remove leading/trailing spaces inside tags
+    .gsub(' data-parsed=""', '')                      # Don't consider this known inky-node artefact
+    .gsub('&#xA0', '&#160')                           # These are the same entity...
+    .gsub(/(align="[^"]+") (class="[^"]+")/, '\2 \1') # Tweak order to match inky-node on container
+    .gsub(/class\="([^"]+)"/) do                      # Sort class names
       classes = $1.split(' ').sort.join(' ')
       %{class="#{classes}"}
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ def reformat_html(html)
     .gsub(%r{<(\w+)([^>]*)>\n</\1>}, '<\1\2/>') # Auto close empty tags, e.g. <hr>\n</hr> => <hr/>
     .gsub(/ "/, '"').gsub(/\=" /, '="')         # Remove leading/trailing spaces inside attributes
     .gsub(/ </, '<').gsub(/> /, '>')            # Remove leading/trailing spaces inside tags
+    .gsub(' data-parsed=""', '')                # Don't consider this known inky-node artefact
     .gsub(/class\="([^"]+)"/) do                # Sort class names
       classes = $1.split(' ').sort.join(' ')
       %{class="#{classes}"}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,10 @@ def reformat_html(html)
     .gsub(%r{<(\w+)([^>]*)>\n</\1>}, '<\1\2/>') # Auto close empty tags, e.g. <hr>\n</hr> => <hr/>
     .gsub(/ "/, '"').gsub(/\=" /, '="')         # Remove leading/trailing spaces inside attributes
     .gsub(/ </, '<').gsub(/> /, '>')            # Remove leading/trailing spaces inside tags
+    .gsub(/class\="([^"]+)"/) do                # Sort class names
+      classes = $1.split(' ').sort.join(' ')
+      %{class="#{classes}"}
+    end
 end
 
 def compare(input, expected)


### PR DESCRIPTION
This uses `inky-cli` to compare the results of the Ruby gem to the node version.

It checks to insure that `inky-cli` is installed correctly and of the right version.

I've only provided a very basic case and it gives me an error:
```
  1) Inky-rb compared to inky-cli for grid components provides the same results for container
     Failure/Error: expect(output_str).to eql(expected_str)

       expected: "<?xmlversion=\"1.0\"?><tablealign=\"center\"class=\"container\"><tbody><tr><td>foo</td></tr></tbody></table>"
            got: "<?xmlversion=\"1.0\"?><tableclass=\"container\"><tbody><tr><td>foo</td></tr></tbody></table>"
```

@kball can you confirm there's a discrepancy here that should be fixed? Also, please :+1: this PR, I'll merge it create more test cases...