### PR TITLE
Remove spurious <?xml version=1.0?>

### DIFF
--- a/lib/inky.rb
+++ b/lib/inky.rb
@@ -33,7 +33,9 @@ module Inky
       raws, str = Inky::Core.extract_raws(xml_string)
       xml_doc = Nokogiri::XML(str)
       transform_doc(xml_doc.root) if components_exist?(xml_doc)
-      Inky::Core.re_inject_raws(xml_doc.to_s, raws)
+      string = xml_doc.to_s
+      string.sub!(/^<\?xml.*\?>\n/, '')
+      Inky::Core.re_inject_raws(string, raws)
     end
 
     def components_exist?(_xml_doc)

--- a/spec/components_spec.rb
+++ b/spec/components_spec.rb
@@ -355,8 +355,8 @@ end
 
 RSpec.describe "raw" do
   it 'creates a wrapper that ignores anything inside' do
-    input = "<body><raw><<LCG Program\TG LCG Coupon Code Default='246996'>></raw></body>"
-    expected = "<?xml version=\"1.0\"?>\n<body><<LCG ProgramTG LCG Coupon Code Default='246996'>></body>\n"
+    input = "<body><raw><<LCG ProgramTG LCG Coupon Code Default='246996'>></raw></body>"
+    expected = "<body><<LCG ProgramTG LCG Coupon Code Default='246996'>></body>\n"
 
     # Can't do vanilla compare because the second will fail to parse
     inky = Inky::Core.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,14 @@
 require 'inky'
 
+def reformat_html(html)
+  html
+    .gsub(/\s+/, ' ')                           # Compact all whitespace to a single space
+    .gsub(/> *</, ">\n<")                       # Use returns between tags
+    .gsub(%r{<(\w+)([^>]*)>\n</\1>}, '<\1\2/>') # Auto close empty tags, e.g. <hr>\n</hr> => <hr/>
+    .gsub(/ "/, '"').gsub(/\=" /, '="')         # Remove leading/trailing spaces inside attributes
+    .gsub(/ </, '<').gsub(/> /, '>')            # Remove leading/trailing spaces inside tags
+end
+
 def compare(input, expected)
   inky = Inky::Core.new
   output = inky.release_the_kraken(input)
@@ -7,7 +16,5 @@ def compare(input, expected)
   # TODO:  Figure out a better way to do html compare in ruby..
   # this is overly dependent on things like class ordering, making it
   # fragile
-  output_str = Nokogiri::XML(output).to_s.gsub(/\s/, '')
-  expected_str = Nokogiri::XML(expected).to_s.gsub(/\s/, '')
-  expect(output_str).to eql(expected_str)
+  expect(reformat_html(output)).to eql(reformat_html(expected))
 end


### PR DESCRIPTION
This was at the beginning of the output since the switch to nokogiri,
see f38942870 (PR #19).

To this in the future, I changed the comparison of results with more explicit rules.
This avoids other potential errors, say if Nokogiri corrects small markup errors
or swallows other markup.

The output for failing tests is also much nicer, in particular there's very helpful diff:

**Before**
```
expected: "<tablealign=\"center\"class=\"container\"><tbody><tr><td>foo</td></tr></tbody></table>"
     got: "<tableclass=\"container\"><tbody><tr><td>foo</td></tr></tbody></table>"
```
**After**
```
expected: "<table align=\"center\" class=\"container\">\n<tbody>\n<tr>\n<td>foo</td>\n</tr>\n</tbody>\n</table>"
     got: "<table class=\"container\">\n<tbody>\n<tr>\n<td>foo</td>\n</tr>\n</tbody>\n</table>"

Diff:
@@ -1,4 +1,4 @@
-<table align="center" class="container">
+<table class="container">
 <tbody>
 <tr>
 <td>foo</td>
```