### PR TITLE
Use `html.children` so inky-rb will work on heroku

### DIFF
--- a/lib/inky.rb
+++ b/lib/inky.rb
@@ -33,7 +33,7 @@ module Inky
       raws, str = Inky::Core.extract_raws(xml_string)
       parse_cmd = str =~ /<html/i ? :parse : :fragment
       html = Nokogiri::HTML.public_send(parse_cmd, str)
-      html.elements.each do |elem|
+      html.children.each do |elem|
         transform_doc(elem)
       end
       string = html.to_html(encoding: 'US-ASCII')


### PR DESCRIPTION
I honestly have no idea why `html.elements` doesn't work and why `html.children` does work, but that's what I found.

The only difference (in theory), afaict, is that `#children` includes text nodes. This doesn't hurt anything (as you can see specs all still pass). However on Heroku, `html.elements` is always empty.

To verify the issue and verify that this fixes it, you'd have to spin up a project on Heroku and verify that `inky-rb` indeed fails to convert emails.

