### PR TITLE
ERB Template and Generator Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,16 @@ Run the following command to set up the required styles and mailer layout:
 rails g inky:install
 ```
 
-(You can specify the generated mailer layout filename like so: `rails g inky:install some_name` and also your prefered
-markup language like: `rails g inky:install mailer_layout slim`)
+You can specify the layout name and templating language with the following options:
+
+```
+Usage:
+  rails generate inky:install [layout_name] [options]
+
+Options:
+  [--haml], [--no-haml]  # Generate layout in Haml
+  [--slim], [--no-slim]  # Generate layout in Slim
+```
 
 Rename your email templates to use the `.inky` file extension. Note that you'll still be able to use your default
 template engine within the `.inky` templates:

--- a/lib/generators/inky/install_generator.rb
+++ b/lib/generators/inky/install_generator.rb
@@ -11,7 +11,7 @@ module Inky
       class_option :slim, desc: "Generate layout in Slim", type: :boolean
 
       def preserve_original_mailer_layout
-        return if layout_name == 'mailer' && extension == 'erb'
+        return unless layout_name == 'mailer' && extension == 'erb'
         original_mailer = File.join(layouts_base_dir, "mailer.html.erb")
         rename_filename = File.join(layouts_base_dir, "old_mailer_#{Time.now.to_i}.html.erb")
         File.rename(original_mailer, rename_filename) if File.exist? original_mailer

--- a/lib/generators/inky/install_generator.rb
+++ b/lib/generators/inky/install_generator.rb
@@ -6,14 +6,16 @@ module Inky
       desc 'Install Foundation for Emails'
       source_root File.join(File.dirname(__FILE__), 'templates')
       argument :layout_name, type: :string, default: 'mailer', banner: 'layout_name'
-      argument :extension,   type: :string, default: 'erb',    banner: 'extension'
+
+      class_option :haml, desc: "Generate layout in Haml", type: :boolean
+      class_option :slim, desc: "Generate layout in Slim", type: :boolean
 
       def preserve_original_mailer_layout
-        return unless layout_name == 'mailer'
-
-        original_mailer = File.join(layouts_base_dir, "mailer.html.#{extension}")
-        rename_filename = File.join(layouts_base_dir, "old_mailer_#{Time.now.to_i}.html.erb")
-        File.rename(original_mailer, rename_filename) if File.exist? original_mailer
+        if layout_name == 'mailer' && extension == 'erb'
+          original_mailer = File.join(layouts_base_dir, "mailer.html.erb")
+          rename_filename = File.join(layouts_base_dir, "old_mailer_#{Time.now.to_i}.html.erb")
+          File.rename(original_mailer, rename_filename) if File.exist? original_mailer
+        end
       end
 
       def create_mailer_stylesheet
@@ -32,6 +34,13 @@ module Inky
 
       def layouts_base_dir
         File.join('app', 'views', 'layouts')
+      end
+
+      def extension
+        %w(haml slim).each do |ext|
+          return ext if options.send(ext)
+        end
+        'erb'
       end
     end
   end

--- a/lib/generators/inky/install_generator.rb
+++ b/lib/generators/inky/install_generator.rb
@@ -11,11 +11,10 @@ module Inky
       class_option :slim, desc: "Generate layout in Slim", type: :boolean
 
       def preserve_original_mailer_layout
-        if layout_name == 'mailer' && extension == 'erb'
-          original_mailer = File.join(layouts_base_dir, "mailer.html.erb")
-          rename_filename = File.join(layouts_base_dir, "old_mailer_#{Time.now.to_i}.html.erb")
-          File.rename(original_mailer, rename_filename) if File.exist? original_mailer
-        end
+        return if layout_name == 'mailer' && extension == 'erb'
+        original_mailer = File.join(layouts_base_dir, "mailer.html.erb")
+        rename_filename = File.join(layouts_base_dir, "old_mailer_#{Time.now.to_i}.html.erb")
+        File.rename(original_mailer, rename_filename) if File.exist? original_mailer
       end
 
       def create_mailer_stylesheet

--- a/lib/generators/inky/templates/mailer_layout.html.erb
+++ b/lib/generators/inky/templates/mailer_layout.html.erb
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width" />
 
-    <%= stylesheet_link_tag "foundation_emails" %>
+    <%%= stylesheet_link_tag "foundation_emails" %>
   </head>
 
   <body>
@@ -12,7 +12,7 @@
       <tr>
         <td class="center" align="center" valign="top">
           <center>
-            <%= yield %>
+            <%%= yield %>
           </center>
         </td>
       </tr>

--- a/lib/inky/rails/version.rb
+++ b/lib/inky/rails/version.rb
@@ -1,6 +1,6 @@
 module Inky
   module Rails
-    VERSION = "1.3.7.1".freeze
+    VERSION = "1.3.7.2".freeze
   end
   NODE_VERSION, GEM_VERSION = Rails::VERSION.rpartition('.').map(&:freeze)
 end


### PR DESCRIPTION
This PR addresses issue #41. The problem here was that ERB's [literal tag delimiters](https://docs.puppet.com/puppet/latest/reference/lang_template_erb.html#literal-tag-delimiters) (`<%%`) were removed from the template, causing the `stylesheet_link_tag` to be evaluated at the context of the InstallGenerator.

Additionally, the install generator was reworked to accept a more intuitive format of arguments and options. Previously, a user would have to specify a layout name in order to be able to then pass in the templating language argument (e.g `rails g inky:install some_name slim`).

The new generator format is more consistent with how we pass options into `foundation-rails` gem. Template type can now be specified without having to also provide a name:

`rails g inky:install --slim`