### PR TITLE
Make column_count configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,29 @@ welcome.html.haml => welcome.html.inky-haml
 pw_reset.html.erb => pw_reset.html.inky-erb
 ```
 
+## Other options
+
+### Column Count
+
+You can change the column count in the initializer too:
+
+```ruby
+# config/initializers/inky.rb
+Inky.configure do |config|
+  config.column_count = 24
+end
+```
+
+Make sure to change the SASS variable as well:
+
+```sass
+# assets/stylesheets/foundation_emails.scss
+# ...
+$grid-column-count: 24;
+
+@import "foundation-emails";
+```
+
 ## Custom Elements
 
 Inky simplifies the process of creating HTML emails by expanding out simple tags like `<row>` and `<column>` into full table syntax. The names of the tags can be changed with the `components` setting.

--- a/lib/inky.rb
+++ b/lib/inky.rb
@@ -25,7 +25,7 @@ module Inky
 
       self.component_lookup = components.invert
 
-      self.column_count = options[:column_count] || 12
+      self.column_count = options[:column_count] || ::Inky.configuration.column_count
 
       self.component_tags = components.values
     end

--- a/lib/inky/configuration.rb
+++ b/lib/inky/configuration.rb
@@ -15,6 +15,7 @@ module Inky
   # ```
   # Inky.configure do |config|
   #   config.template_engine = :slim
+  #   config.column_count = 24
   # end
   # ```
   def self.configure
@@ -22,10 +23,11 @@ module Inky
   end
 
   class Configuration
-    attr_accessor :template_engine
+    attr_accessor :template_engine, :column_count
 
     def initialize
       @template_engine = :erb
+      @column_count = 12
     end
   end
 end

--- a/lib/inky/rails/template_handler.rb
+++ b/lib/inky/rails/template_handler.rb
@@ -14,6 +14,7 @@ module Inky
 
       def call(template)
         compiled_source = engine_handler.call(template)
+
         "Inky::Core.new.release_the_kraken(begin; #{compiled_source};end)"
       end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -14,10 +14,16 @@ RSpec.describe "Configuration" do
   end
 
   describe "#configuration=" do
-    it "can set value" do
+    it "can set template_engine" do
       config = Inky::Configuration.new
       config.template_engine = :haml
       expect(config.template_engine).to eq(:haml)
+    end
+
+    it "can set column_count" do
+      config = Inky::Configuration.new
+      config.column_count = 4
+      expect(config.column_count).to eq(4)
     end
   end
 

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -57,6 +57,50 @@ RSpec.describe 'Grid' do
     compare(input, expected)
   end
 
+  it 'creates a single column with default large and small classes' do
+    input = '<columns>One</columns>'
+    expected = <<-HTML
+      <th class="small-12 large-12 columns first last">
+        <table>
+          <tr>
+            <th>One</th>
+            <th class="expander"></th>
+          </tr>
+        </table>
+      </th>
+    HTML
+
+    compare(input, expected)
+  end
+
+  it 'creates a single column with default large and small classes using the column_count option' do
+    begin
+      @previous_column_count = Inky.configuration.column_count
+
+      Inky.configure do |config|
+        config.column_count = 5
+      end
+
+      input = '<columns>One</columns>'
+      expected = <<-HTML
+        <th class="small-5 large-5 columns first last">
+          <table>
+            <tr>
+              <th>One</th>
+              <th class="expander"></th>
+            </tr>
+          </table>
+        </th>
+      HTML
+
+      compare(input, expected)
+    ensure
+      Inky.configure do |config|
+        config.column_count = @previous_column_count
+      end
+    end
+  end
+
   it 'creates a single column with first and last classes' do
     input = '<columns large="12" small="12">One</columns>'
     expected = <<-HTML


### PR DESCRIPTION
As it says in the tin.

Seems there's no way to pass in options to `Inky::Core`, so I've added a shortcut.

Also related to #52