### PR TITLE
Classes being duplicated an excessive amount of times

### DIFF
--- a/lib/inky/component_factory.rb
+++ b/lib/inky/component_factory.rb
@@ -22,7 +22,10 @@ module Inky
     end
 
     def _combine_classes(elem, extra_classes)
-      [elem['class'], extra_classes].join(' ')
+      existing = elem['class'].to_s.split(' ')
+      to_add = extra_classes.to_s.split(' ')
+
+      (existing + to_add).uniq.join(' ')
     end
 
     def _combine_attributes(elem, extra_classes = nil)


### PR DESCRIPTION
We have found when using inky-rb that our emails are being bloated by many declarations of the same class on certain elements, in particular `<menu>` tags deeply nested in our template. They produce output HTML like so;

```
<th class=" menu-item float-center float-center float-center float-center float-center float-center float-center float-center float-center float-center float-center float-center float-center float-center float-center float-center float-center float-center" [...omitted]>
```

This appears to be due to the fact that the `_combine_classes` function does not check for the existence of a class before appending it to the existing list. Included is a pull request to resolve this issue. After the change, HTML like so is produced;

```
<th class="menu-item float-center" [...omitted]>
```