### PR TITLE
Encoding

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    inky-rb (1.3.7.1)
+    inky-rb (1.3.7.2)
       foundation_emails (~> 2)
       nokogiri
 
@@ -61,7 +61,7 @@ GEM
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
-    json (1.8.3)
+    json (1.8.6)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -165,4 +165,4 @@ DEPENDENCIES
   slim
 
 BUNDLED WITH
-   1.13.6
+   1.14.6

--- a/lib/inky.rb
+++ b/lib/inky.rb
@@ -31,13 +31,15 @@ module Inky
     end
 
     def release_the_kraken(html_string)
-      html_string.force_encoding('utf-8') # transform_doc barfs if encoding is ASCII-8bit
+      if html_string.encoding.name == "ASCII-8BIT"
+        html_string.force_encoding('utf-8') # transform_doc barfs if encoding is ASCII-8bit
+      end
       html_string = html_string.gsub(/doctype/i, 'DOCTYPE')
       raws, str = Inky::Core.extract_raws(html_string)
       parse_cmd = str =~ /<html/i ? :parse : :fragment
       html = Nokogiri::HTML.public_send(parse_cmd, str)
       transform_doc(html)
-      string = html.to_html(encoding: 'US-ASCII')
+      string = html.to_html
       Inky::Core.re_inject_raws(string, raws)
     end
 

--- a/spec/grid_spec.rb
+++ b/spec/grid_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Container" do
   it 'works when parsing a full HTML document' do
     input = <<-INKY
       <!doctype html> <html>
-        <head><meta http-equiv="Content-Type" content="text/html; charset=US-ASCII"></head>
+        <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"></head>
         <body>
           <container></container>
         </body>
@@ -27,7 +27,7 @@ RSpec.describe "Container" do
     expected = <<-HTML
       <!DOCTYPE html>
       <html>
-        <head><meta http-equiv="Content-Type" content="text/html; charset=US-ASCII"></head>
+        <head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"></head>
         <body>
           <table class="container" align="center">
             <tbody>

--- a/spec/inky_spec.rb
+++ b/spec/inky_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'spec_helper'
 
 RSpec.describe "Inky#release_the_kraken" do
@@ -15,5 +17,38 @@ RSpec.describe "Inky#release_the_kraken" do
 
     output = Inky::Core.new.release_the_kraken(input)
     expect_same_html(output, expected)
+  end
+
+  it "works on utf-8 text" do
+    input = '<container><p>Güten tag Marc-André</p></container>'
+    expected = <<-HTML
+      <table class="container" align="center">
+        <tbody>
+          <tr>
+            <td><p>Güten tag Marc-André</p></td>
+          </tr>
+        </tbody>
+      </table>
+    HTML
+
+    output = Inky::Core.new.release_the_kraken(input)
+    expect_same_html(output, expected)
+  end
+
+  it "works on US-ASCII text" do
+    input = '<container><p>G&#252;ten tag Marc-Andr&#233;</p></container>'.force_encoding("us-ascii")
+    expected = <<-HTML
+      <table class="container" align="center">
+        <tbody>
+          <tr>
+            <td><p>G&#252;ten tag Marc-Andr&#233;</p></td>
+          </tr>
+        </tbody>
+      </table>
+    HTML
+
+    output = Inky::Core.new.release_the_kraken(input)
+    expect_same_html(output, expected)
+    output.encoding.name.should == 'US-ASCII'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'inky'
 
 def reformat_html(html)
@@ -8,7 +10,7 @@ def reformat_html(html)
     .gsub(/ "/, '"').gsub(/\=" /, '="')               # Remove leading/trailing spaces inside attributes
     .gsub(/ </, '<').gsub(/> /, '>')                  # Remove leading/trailing spaces inside tags
     .gsub(' data-parsed=""', '')                      # Don't consider this known inky-node artefact
-    .gsub('&#xA0', '&#160')                           # These are the same entity...
+    .gsub('&#xA0;', ' ')                              # These are the same entity...
     .gsub(/(align="[^"]+") (class="[^"]+")/, '\2 \1') # Tweak order to match inky-node on container
     .gsub(/class\="([^"]+)"/) do                      # Sort class names
       classes = $1.split(' ').sort.join(' ')

--- a/spec/test_app/spec/features/inky_spec.rb
+++ b/spec/test_app/spec/features/inky_spec.rb
@@ -53,7 +53,7 @@ describe 'Rails', type: :feature do
       <!DOCTYPE html>
       <html>
         <head>
-          <meta http-equiv="Content-Type" content="text/html; charset=US-ASCII">
+          <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
           <title>inky : layout</title>
         </head>
         <body>


### PR DESCRIPTION
This attempts to resolve #57.

In cases of input that is binary (which seems to be the case for output with `slim`, for example), the html parsing fails miserably, so we still force the encoding to utf-8, but no longer transform ascii. For other cases, encoding is respected and kept as is.

The idea is: it's not inky's job to escape entities or anything, let that job be done by `premailer` and the like.