### PR TITLE
Specify Project License in gemspec

### DIFF
--- a/inky.gemspec
+++ b/inky.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.authors     = ["ZURB"]
   s.email       = ['foundation@zurb.com']
   s.homepage    = 'https://github.com/zurb/inky-rb'
+  s.licenses    = ['MIT']
 
   s.files         = `git ls-files -z`.split("\x0")
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
License specification in Gemspec to allow dependency tracking services like FOSSA to properly identify this project's license. 

Documentation here: http://guides.rubygems.org/specification-reference/#licenses=