### PR TITLE
Fix deprecation warnings on Rails 6

### DIFF
--- a/lib/inky/rails/template_handler.rb
+++ b/lib/inky/rails/template_handler.rb
@@ -13,9 +13,13 @@ module Inky
           raise("No template handler found for #{type}")
       end
 
-      def call(template)
-        compiled_source = engine_handler.call(template)
-
+      def call(template, source = nil)
+        compiled_source =
+          if source
+            engine_handler.call(template, source)
+          else
+            engine_handler.call(template)
+          end
         "Inky::Core.new.release_the_kraken(begin; #{compiled_source};end)"
       end
 


### PR DESCRIPTION
I came across the depircation warning when upgrading to Rails 6.0.0.beta2:

```
Inky::Rails::TemplateHandler#call(template, source)
 (called from <top (required)> at /Users/kylekeesling/Sites/pass-tools/config/environment.rb:6)
DEPRECATION WARNING: Single arity template handlers are deprecated.  Template handlers must
now accept two parameters, the view object and the source for the view object.
Change:
  >> Inky::Rails::TemplateHandler#call(template)
To:
  >> Inky::Rails::TemplateHandler#call(template, source)

```
I had this error coming from 2 different gems - this one and `rails/coffee-rails`. When I saw coffee-rails had been patched I dug in and found this fix and cribbed it to patch this one and it seems to do the trick!

https://github.com/rails/coffee-rails/blob/cbf6af63ac57cea246b75275ba50769d12f43316/lib/coffee/rails/template_handler.rb