### PR TITLE
Improve JRuby support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -153,5 +153,8 @@ Metrics/BlockLength:
     - 'Rakefile'
     - 'spec/**/*.rb'
 
+Style/MutableConstant:
+  Enabled: false
+
 Style/Encoding:
   Enabled: false

--- a/lib/inky.rb
+++ b/lib/inky.rb
@@ -40,6 +40,7 @@ module Inky
       html = Nokogiri::HTML.public_send(parse_cmd, str)
       transform_doc(html)
       string = html.to_html
+      string.gsub!(INTERIM_TH_TAG_REGEX, 'th')
       Inky::Core.re_inject_raws(string, raws)
     end
 

--- a/lib/inky/component_factory.rb
+++ b/lib/inky/component_factory.rb
@@ -12,6 +12,11 @@ module Inky
     tags = tags.to_set if tags.respond_to? :to_set
     IGNORED_ON_PASSTHROUGH = tags.freeze
 
+    # These constants are used to circumvent an issue with JRuby Nokogiri.
+    # For more details see https://github.com/zurb/inky-rb/pull/94
+    INTERIM_TH_TAG = 'inky-interim-th'.freeze
+    INTERIM_TH_TAG_REGEX = %r{(?<=\<|\<\/)#{Regexp.escape(INTERIM_TH_TAG)}}
+
     def _pass_through_attributes(elem)
       elem.attributes.reject { |e| IGNORED_ON_PASSTHROUGH.include?(e.downcase) }.map do |name, value|
         %{#{name}="#{value}" }
@@ -60,7 +65,7 @@ module Inky
     def _transform_menu_item(component, inner)
       target = _target_attribute(component)
       attributes = _combine_attributes(component, 'menu-item')
-      %{<th #{attributes}><a href="#{component.attr('href')}"#{target}>#{inner}</a></th>}
+      %{<#{INTERIM_TH_TAG} #{attributes}><a href="#{component.attr('href')}"#{target}>#{inner}</a></#{INTERIM_TH_TAG}>}
     end
 
     def _transform_container(component, inner)
@@ -91,7 +96,7 @@ module Inky
       subrows = component.elements.css(".row").to_a.concat(component.elements.css("row").to_a)
       expander = %{<th class="expander"></th>} if large_size.to_i == column_count && subrows.empty?
 
-      %{<th class="#{classes}" #{_pass_through_attributes(component)}><table><tr><th>#{inner}</th>#{expander}</tr></table></th>}
+      %{<#{INTERIM_TH_TAG} class="#{classes}" #{_pass_through_attributes(component)}><table><tr><th>#{inner}</th>#{expander}</tr></table></#{INTERIM_TH_TAG}>}
     end
 
     def _transform_block_grid(component, inner)


### PR DESCRIPTION
`inky-rb` is not correctly transforming templates in JRuby - caused by Nokogiri's different implementations for MRI and JRuby. In the JRuby variant NekoHTML is being used and a specific feature of NekoHTML seems to be the reason. Under the Features section on http://nekohtml.sourceforge.net/settings.html the `html/features/balance-tags` feature is described to the following:

> Specifies if the NekoHTML parser should attempt to balance the tags in the parsed document. Balancing the tags fixes up many common mistakes by adding missing parent elements, automatically closing elements with optional end tags, and correcting unbalanced inline element tags. In order to process HTML documents as XML, this feature should not be turned off. This feature is provided as a performance enhancement for applications that only care about the appearance of specific elements, attributes, and/or content regardless of the document's ill-formed structure. 

In terms of Inky the issue can be seen with an input template like this:

```html
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<html xmlns="http://www.w3.org/1999/xhtml">
  <head>
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
    <meta name="viewport" content="width=device-width" />
  </head>
  <body>
    <table class="body" data-made-with-foundation>
      <tr>
        <td class="center" align="center" valign="top">
          <center>
            <container class="collapse">
              <row class="mailer-header">
                <columns small="12" large="12">
                  <center>
                    <img width="128" height="30" src="" alt="Image"/>
                  </center>
                </columns>
              </row>
            </container>
          </center>
        </td>
      </tr>
    </table>
  </body>
</html>
```

In **MRI** that template renders to (formatted):

```html
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<html xmlns="http://www.w3.org/1999/xhtml">

<head>
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
    <meta name="viewport" content="width=device-width">
</head>

<body>
    <table class="body" data-made-with-foundation>
        <tr>
            <td class="center" align="center" valign="top">
                <center>
                    <table class="collapse container float-center" align="center">
                        <tbody>
                            <tr>
                                <td>
                                    <table class="mailer-header row">
                                        <tbody>
                                            <tr>
                                                <th class="small-12 large-12 columns first last">
                                                    <table>
                                                        <tr>
                                                            <th>
                                                                <center>
                                                                    <img width="128" height="30" src="" alt="Image" align="center" class="float-center">
                                                                </center>
                                                            </th>
                                                            <th class="expander"></th>
                                                        </tr>
                                                    </table>
                                                </th>
                                            </tr>
                                        </tbody>
                                    </table>
                                </td>
                            </tr>
                        </tbody>
                    </table>
                </center>
            </td>
        </tr>
    </table>
</body>

</html>
```

In **JRuby** that template renders to (formatted):

```html
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<html xmlns="http://www.w3.org/1999/xhtml">

<head>
    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
    <meta content="width=device-width" name="viewport">
</head>

<body>
    <table class="body" data-made-with-foundation="">
        <tbody>
            <tr>
                <td align="center" class="center" valign="top">
                    <center>
                        <table align="center" class="collapse container float-center">
                            <tbody>
                                <tr>
                                    <td>
                                        <table class="mailer-header row">
                                            <tbody>
                                                <tr>
                                                    <table>
                                                        <tbody>
                                                            <tr>
                                                                <th>
                                                                    <center>
                                                                        <img align="center" alt="Image" class="float-center" height="30" src="" width="128">
                                                                    </center>
                                                                </th>
                                                                <th class="expander"></th>
                                                            </tr>
                                                        </tbody>
                                                    </table>
                                                </tr>
                                            </tbody>
                                        </table>
                                    </td>
                                </tr>
                            </tbody>
                        </table>
                    </center>
                </td>
            </tr>
        </tbody>
    </table>

</body>

</html>
```

The missing part in the JRuby output is `<th class="small-12 large-12 columns first last">`.

As far as I can tell the difference is caused by the way Inky recursively transforms the template. The intermediate steps produces invalid HTML, for instance in `Inky::ComponentFactory#_transform_columns` where it returns a `<th>` which replaces the `<columns>` element. MRI Nokogiri handles this fine but JRuby Nokogiri strips the `<th>` because it's not inside a `<table>` (to begin with).

A simple solution is to use a different tag in the transformation process itself and then end by converting it back to `<th>`.