### PR TITLE
fix raw tag parsing to include multi-line html

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,21 @@ Here are the names of the defaults:
 }
 ```
 
+## Raw HTML
+
+If you need to include raw html, you can wrap raw content in `<raw>` tags
+
+```html
+<raw>
+  <button></button>
+  <asdf></asdf>
+</raw>
+```
+
+This is a feature intended for advanced users. You will be responsible for ensuring all markup between `<raw>` tags is valid. All content after an opening `<raw>` tag will be inserted "As Is" until the next closing `</raw>` tag.
+
+This means that `<raw>` tags CANNOT be nested
+
 ## Programmatic Use
 
 The Inky parser can be accessed directly for programmatic use.

--- a/lib/inky.rb
+++ b/lib/inky.rb
@@ -58,7 +58,7 @@ module Inky
     def self.extract_raws(string)
       raws = []
       i = 0
-      regex = %r(< *raw *>(.*?)</ *raw *>)
+      regex = %r(<\s*raw\s*>((?!</\s*raw\s*>).*?)</\s*raw\s*>)misux
       str = string
       while raw = str.match(regex)
         raws[i] = raw[1]

--- a/spec/components_spec.rb
+++ b/spec/components_spec.rb
@@ -361,4 +361,43 @@ RSpec.describe "raw" do
     output = inky.release_the_kraken(input)
     expect(output).to eql(expected)
   end
+
+  it 'works on multiple lines' do
+    input = <<-HTML
+      <body>
+        <raw>
+          <<LCG ProgramTG LCG Coupon Code Default='246996'>>\
+          <button>
+        </raw>
+      </body>
+    HTML
+
+    # Can't do vanilla compare because the second will fail to parse
+    inky = Inky::Core.new
+    output = inky.release_the_kraken(input)
+    expect(output).to include("<<LCG ProgramTG LCG Coupon Code Default='246996'>>")
+    expect(output).to include("<button>")
+    expect(output).to_not include('raw')
+    expect(output).to_not include('<table class="button">')
+  end
+
+  it 'stops at the first </raw> tag' do
+    input = <<-HTML
+      <body>
+        <raw>
+          <<LCG ProgramTG LCG Coupon Code Default='246996'>>
+        </raw>
+        <button href="#">Test</button>
+        </raw>
+      </body>
+    HTML
+    expected = "<<LCG ProgramTG LCG Coupon Code Default='246996'>>"
+
+    # Can't do vanilla compare because the second will fail to parse
+    inky = Inky::Core.new
+    output = inky.release_the_kraken(input)
+    expect(output).to include(expected)
+    expect(output).to include('<table class="button">')
+    expect(output).to_not include('<button>')
+  end
 end


### PR DESCRIPTION
fixes raw tag parsing mentioned in #95 

since this is an HTML based library, and raw tags are supported in the repo, only allowing single line parsing is a huge surprise. this fixes that surprise