### PR TITLE
Fix Rails 7.1 compatibility with new OutputBuffer

### DIFF
--- a/lib/inky.rb
+++ b/lib/inky.rb
@@ -35,7 +35,12 @@ module Inky
       if html_string.encoding.name == "ASCII-8BIT"
         html_string.force_encoding('utf-8') # transform_doc barfs if encoding is ASCII-8bit
       end
-      html_string = html_string.gsub(/doctype/i, 'DOCTYPE')
+      html_string =
+        if html_string.respond_to?(:gsub)
+          html_string.gsub(/doctype/i, 'DOCTYPE')
+        else # Rails 7.1+
+          html_string.to_str.gsub(/doctype/i, 'DOCTYPE')
+        end
       raws, str = Inky::Core.extract_raws(html_string)
       parse_cmd = str =~ /<html/i ? :parse : :fragment
       html = Nokogiri::HTML.public_send(parse_cmd, str)


### PR DESCRIPTION
Running inky-rb (inky-slim templates to be precise), in Rails 7.1 leads to an error:

```
     Failure/Error: doctype strict

     ActionView::Template::Error:
       undefined method `gsub' for #<ActionView::OutputBuffer:0x00007fab3e4ffdf8>
     # /.../gems/inky-rb-1.4.2.0/lib/inky.rb:39:in `release_the_kraken'
     # ./app/views/layouts/application_mailer.html.inky-slim:1:in `_app_views_layouts_application_mailer_html_inky_slim__782571883712689889_89280'
     # /.../gems/2.7.0/bundler/gems/rails-a3d15ade680d/actionview/lib/action_view/base.rb:264:in `public_send'
```

The new OutputBuffer does not seems to implement the string delegation methods anymore.


This PR seems to fix the issue by just calling ``.to_str`` on the buffer before gsub. 