### PR TITLE
Rails 7.1 compatibility remixed

### DIFF
--- a/lib/inky.rb
+++ b/lib/inky.rb
@@ -32,6 +32,9 @@ module Inky
     end
 
     def release_the_kraken(html_string)
+      # Force conversion to string. (required for Rails 7.1+)
+      html_string = html_string.to_s
+
       if html_string.encoding.name == "ASCII-8BIT"
         html_string.force_encoding('utf-8') # transform_doc barfs if encoding is ASCII-8bit
       end


### PR DESCRIPTION
Adapted from #110 

* Using `to_s` instead of `to_str`, as I believe it is a mistake for Rails to implement `to_str` but not `gsub`.
* Simpler than calling `respond_to?` Doing conversion when not needed should not have an impact. My guess is it's even more performant, but we couldn't care less here.